### PR TITLE
Get app working on Mac & iOs

### DIFF
--- a/MauiBeatCounter/Assets.xcassets/AppIcon-1.appiconset/Contents.json
+++ b/MauiBeatCounter/Assets.xcassets/AppIcon-1.appiconset/Contents.json
@@ -1,0 +1,1 @@
+{"images":[],"info":{"version":1,"author":"xcode"}}

--- a/MauiBeatCounter/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/MauiBeatCounter/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,1 @@
+{"images":[],"info":{"version":1,"author":"xcode"}}

--- a/MauiBeatCounter/MauiBeatCounter.csproj
+++ b/MauiBeatCounter/MauiBeatCounter.csproj
@@ -30,6 +30,12 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
+	  <CreatePackage>false</CreatePackage>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7.0-ios|AnyCPU'">
+	  <CreatePackage>false</CreatePackage>
+	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -53,4 +59,12 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <None Remove="Assets.xcassets\AppIcon.appiconset\Contents.json" />
+	  <None Remove="Assets.xcassets\AppIcon-1.appiconset\Contents.json" />
+	</ItemGroup>
+	<ItemGroup>
+	  <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
+	  <ImageAsset Include="Assets.xcassets\AppIcon-1.appiconset\Contents.json" />
+	</ItemGroup>
 </Project>

--- a/MauiBeatCounter/Platforms/iOS/Info.plist
+++ b/MauiBeatCounter/Platforms/iOS/Info.plist
@@ -26,7 +26,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.gramamoto.mauibeatcounter</string>
 	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
+	<string>Assets.xcassets/AppIcon-1.appiconset</string>
+	<key>MinimumOSVersion</key>
+	<string>11.0</string>
 </dict>
 </plist>

--- a/MauiBeatCounter/View/MainPage.xaml
+++ b/MauiBeatCounter/View/MainPage.xaml
@@ -65,7 +65,7 @@
             <Border
                 Grid.Row="2"
                 Grid.ColumnSpan="2"
-                IsVisible="{Binding ShowMeasures}"
+
                 Stroke="Black"
                 StrokeThickness="2"
                 StrokeShape="RoundRectangle 20"
@@ -87,7 +87,7 @@
                 VerticalOptions="End"
                 HorizontalOptions="Center">
                 <Label 
-                    IsVisible="{OnPlatform Default=False, Android=True}"
+                    IsVisible="{OnPlatform Default=True, WinUI=False}"
                     Text="Meter:"
                     VerticalOptions="Center"/>
                 <Picker 
@@ -102,16 +102,16 @@
             <HorizontalStackLayout 
                 Grid.Row="3"
                 Grid.Column="1"
+                IsVisible="{Binding ShowMeasures}"
                 VerticalOptions="End"
                 HorizontalOptions="Center">
                 <Label
-                    IsVisible="{OnPlatform Default=False, Android=True}"
+                    IsVisible="{OnPlatform Default=True, WinUI=False}"
                     Text="Count By:"
                     VerticalOptions="Center" />
                 <Picker
                     Margin="20,20"
                     Title="Count by:" 
-                    IsVisible="{Binding ShowMeasures}"
                     ItemsSource="{Binding MethodOptions}"
                     ItemDisplayBinding="{Binding name}"
                     SelectedItem="{Binding CurrentMethod}"


### PR DESCRIPTION
Most of the changes resulted from setting things up to run on Mac and IPhone.

The changes to main.xaml were to set the visibility of the label to true on everything except windows, which appears to be the only picker control that displays the label and to correct an issue with hiding the label when the control is hidden.